### PR TITLE
Add API financial statement retrieval for multiple companies

### DIFF
--- a/rik_screener/api_workspace/__init__.py
+++ b/rik_screener/api_workspace/__init__.py
@@ -1,9 +1,10 @@
-from .main_orchestrator import get_latest_reports_info
+from .main_orchestrator import get_latest_reports_info, get_financial_statements
 from .config_auth import set_api_config, get_api_config
 from .endpoints import get_annual_reports_list, get_company_basic_info
 
 __all__ = [
     'get_latest_reports_info',
+    'get_financial_statements',
     'set_api_config',
     'get_api_config',
     'get_annual_reports_list',

--- a/rik_screener/api_workspace/data_processors.py
+++ b/rik_screener/api_workspace/data_processors.py
@@ -1,6 +1,23 @@
 import pandas as pd
 import xml.etree.ElementTree as ET
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Iterable
+
+STATEMENT_METADATA: Dict[str, Dict[str, List[str]]] = {
+    "BS": {
+        "primary": ["Bilanss"],
+        "alternatives": []
+    },
+    "IS": {
+        "primary": ["Kasumiaruanne skeem 1"],
+        "alternatives": ["Kasumiaruanne skeem 2"]
+    }
+}
+
+def _safe_text(element: Optional[ET.Element]) -> Optional[str]:
+    if element is None or element.text is None:
+        return None
+    text = element.text.strip()
+    return text if text else None
 
 def parse_annual_reports_response(xml_response: ET.Element, company_code: str) -> Optional[Dict[str, Any]]:
     try:
@@ -51,10 +68,118 @@ def parse_company_info_response(xml_response: ET.Element, company_code: str) -> 
 
 def create_latest_reports_dataframe(reports_data: List[Dict[str, Any]], names_data: Optional[Dict[str, str]] = None) -> pd.DataFrame:
     df = pd.DataFrame(reports_data)
-    
+
     if names_data:
         df['company_name'] = df['company_code'].map(names_data)
         cols = ['company_code', 'company_name', 'latest_year', 'period_start', 'period_end']
         df = df[cols]
-    
+
     return df
+
+def extract_statement_code(
+    xml_response: ET.Element,
+    years: Iterable[int],
+    statement_type: str
+) -> str:
+    ns = {
+        'ns1': 'http://arireg.x-road.eu/producer/',
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/'
+    }
+
+    metadata = STATEMENT_METADATA.get(statement_type.upper())
+    if metadata is None:
+        raise ValueError(f"Unsupported statement type '{statement_type}'")
+
+    entries = xml_response.findall('.//ns1:majandusaasta_aruanded', ns)
+    if not entries:
+        raise ValueError("No annual reports available for the requested company")
+
+    codes: List[str] = []
+
+    for year in years:
+        primary_code: Optional[str] = None
+        alternative_code: Optional[str] = None
+
+        for entry in entries:
+            entry_year = _safe_text(entry.find('ns1:aruande_aasta', ns))
+            entry_name = _safe_text(entry.find('ns1:aruande_nimetus', ns))
+            entry_code = _safe_text(entry.find('ns1:aruande_kood', ns))
+
+            if entry_year is None or entry_name is None or entry_code is None:
+                continue
+
+            try:
+                entry_year_int = int(entry_year)
+            except ValueError:
+                continue
+
+            if entry_year_int != year:
+                continue
+
+            if entry_name in metadata['primary']:
+                primary_code = entry_code
+                break
+
+            if entry_name in metadata['alternatives']:
+                alternative_code = entry_code
+
+        if primary_code is not None:
+            codes.append(primary_code)
+        elif alternative_code is not None:
+            codes.append(alternative_code)
+        else:
+            raise ValueError(f"No {statement_type.upper()} code found for year {year}")
+
+    unique_codes = set(codes)
+    if len(unique_codes) > 1:
+        raise ValueError("Change in reporting structure detected across requested years")
+
+    return codes[0]
+
+def parse_financial_statement_response(xml_response: ET.Element) -> pd.DataFrame:
+    ns = {
+        'ns1': 'http://arireg.x-road.eu/producer/',
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/'
+    }
+
+    rows = []
+
+    for entry in xml_response.findall('.//ns1:majandusaasta_aruanded_read', ns):
+        line_code = _safe_text(entry.find('ns1:rea_nr', ns))
+        line_name = _safe_text(entry.find('ns1:rea_nimetus', ns))
+
+        for column in entry.findall('ns1:majandusaasta_aruanded_veerud', ns):
+            column_code = _safe_text(column.find('ns1:veeru_kood', ns))
+            column_name = _safe_text(column.find('ns1:veeru_nimetus', ns))
+            value_text = _safe_text(column.find('ns1:vaartus', ns))
+
+            if line_code is None or column_code is None:
+                continue
+
+            value = pd.to_numeric(value_text, errors='coerce') if value_text is not None else None
+
+            rows.append({
+                'line_code': line_code,
+                'line_name': line_name,
+                'column_code': column_code,
+                'column_name': column_name,
+                'value': value
+            })
+
+    if not rows:
+        return pd.DataFrame(columns=['line_code', 'line_name'])
+
+    df = pd.DataFrame(rows)
+
+    pivot = df.pivot_table(
+        index=['line_code', 'line_name'],
+        columns='column_code',
+        values='value',
+        aggfunc='first'
+    )
+
+    pivot = pivot.sort_index(axis=1)
+    pivot.columns = pivot.columns.astype(str)
+    pivot.reset_index(inplace=True)
+
+    return pivot

--- a/rik_screener/api_workspace/endpoints.py
+++ b/rik_screener/api_workspace/endpoints.py
@@ -11,3 +11,18 @@ def get_company_basic_info(company_code: str) -> Optional[ET.Element]:
     client = SOAPClient()
     params = {"ariregistri_kood": company_code}
     return client.call_endpoint("lihtandmed_v2", params)
+
+def get_financial_statement_details(
+    company_code: str,
+    statement_code: str,
+    year: int
+) -> Optional[ET.Element]:
+    """Retrieve a specific financial statement for a company and year."""
+
+    client = SOAPClient()
+    params = {
+        "ariregistri_kood": company_code,
+        "aruande_liik": statement_code,
+        "aruandeaasta": str(year)
+    }
+    return client.call_endpoint("majandusaastaAruanneteKirjed_v1", params)

--- a/rik_screener/api_workspace/main_orchestrator.py
+++ b/rik_screener/api_workspace/main_orchestrator.py
@@ -1,9 +1,22 @@
+from datetime import datetime
+from typing import Iterable, List, Optional, Tuple
+
 import pandas as pd
-from typing import List, Optional
+
 from .config_auth import set_api_config
-from .endpoints import get_annual_reports_list, get_company_basic_info
-from .data_processors import parse_annual_reports_response, parse_company_info_response, create_latest_reports_dataframe
-from .utils import validate_company_codes, format_progress
+from .endpoints import (
+    get_annual_reports_list,
+    get_company_basic_info,
+    get_financial_statement_details,
+)
+from .data_processors import (
+    create_latest_reports_dataframe,
+    extract_statement_code,
+    parse_annual_reports_response,
+    parse_company_info_response,
+    parse_financial_statement_response,
+)
+from .utils import format_progress, validate_company_codes
 
 def get_latest_reports_info(
     company_codes: List[str],
@@ -55,7 +68,166 @@ def get_latest_reports_info(
                     names_data[company_code] = company_name
     
     df = create_latest_reports_dataframe(reports_data, names_data)
-    
+
     print(f"\nCompleted: {len(df)} companies processed successfully")
-    
+
     return df
+
+def _generate_years(starting_year: int, num_requests: int, step: int) -> List[int]:
+    return [starting_year - (step * i) for i in range(num_requests)]
+
+def _merge_year_frames(existing: pd.DataFrame, new_frame: pd.DataFrame) -> pd.DataFrame:
+    if existing is None:
+        return new_frame
+
+    union_index = existing.index.union(new_frame.index)
+
+    existing_values = existing.drop(columns=['line_name'], errors='ignore').reindex(union_index)
+    new_values = new_frame.drop(columns=['line_name'], errors='ignore').reindex(union_index)
+
+    merged_values = pd.concat([existing_values, new_values], axis=1)
+
+    existing_names = existing['line_name'] if 'line_name' in existing else pd.Series(dtype=object)
+    new_names = new_frame['line_name'] if 'line_name' in new_frame else pd.Series(dtype=object)
+
+    if existing_names.empty and not new_names.empty:
+        merged_names = new_names.reindex(union_index)
+    elif new_names.empty and not existing_names.empty:
+        merged_names = existing_names.reindex(union_index)
+    else:
+        merged_names = existing_names.reindex(union_index).combine_first(new_names.reindex(union_index))
+
+    if not merged_names.empty:
+        merged_values.insert(0, 'line_name', merged_names)
+
+    merged_values.index.name = 'line_code'
+
+    return merged_values
+
+def _collect_company_statements(
+    company_code: str,
+    years: Iterable[int],
+    statement_type: str
+) -> Optional[Tuple[pd.Series, pd.DataFrame]]:
+
+    xml_list = get_annual_reports_list(company_code)
+    if xml_list is None:
+        print(f"Failed to retrieve annual reports list for {company_code}")
+        return None
+
+    try:
+        statement_code = extract_statement_code(xml_list, years, statement_type)
+    except ValueError as exc:
+        print(f"{company_code}: {exc}")
+        return None
+
+    combined_frame: Optional[pd.DataFrame] = None
+
+    for year in years:
+        statement_xml = get_financial_statement_details(company_code, statement_code, year)
+
+        if statement_xml is None:
+            print(f"{company_code}: failed to retrieve {statement_type} for {year}")
+            continue
+
+        year_frame = parse_financial_statement_response(statement_xml)
+
+        if year_frame.empty:
+            continue
+
+        year_frame = year_frame.set_index('line_code')
+
+        value_columns = [col for col in year_frame.columns if col != 'line_name']
+        rename_map = {col: f"{year}_{col}" for col in value_columns}
+        year_frame = year_frame.rename(columns=rename_map)
+
+        combined_frame = _merge_year_frames(combined_frame, year_frame)
+
+    if combined_frame is None or combined_frame.empty:
+        print(f"{company_code}: no statement data retrieved")
+        return None
+
+    value_frame = combined_frame.drop(columns=['line_name'], errors='ignore')
+
+    if value_frame.empty:
+        print(f"{company_code}: statement contains no numeric values")
+        return None
+
+    line_names = combined_frame['line_name'] if 'line_name' in combined_frame else pd.Series(dtype=object)
+    line_names = line_names.reindex(value_frame.index)
+    line_names.name = 'line_name'
+
+    multi_columns = pd.MultiIndex.from_tuples(
+        [(company_code, column) for column in value_frame.columns],
+        names=['company_code', 'period']
+    )
+
+    value_frame.columns = multi_columns
+    value_frame.index.name = 'line_code'
+
+    return line_names, value_frame
+
+def get_financial_statements(
+    company_codes: List[str],
+    username: str,
+    password: str,
+    statement_type: str = "BS",
+    starting_year: Optional[int] = None,
+    num_requests: int = 1,
+    year_step: int = 2,
+    rate_limit: int = 20
+) -> pd.DataFrame:
+
+    if num_requests < 1:
+        raise ValueError("num_requests must be at least 1")
+
+    if year_step < 1:
+        raise ValueError("year_step must be at least 1")
+
+    if starting_year is None:
+        starting_year = datetime.utcnow().year
+
+    years = _generate_years(starting_year, num_requests, year_step)
+
+    set_api_config(username, password, rate_limit)
+
+    valid_codes = validate_company_codes(company_codes)
+
+    if not valid_codes:
+        print("No valid company codes provided")
+        return pd.DataFrame()
+
+    print(f"Processing {len(valid_codes)} companies for {statement_type.upper()} statements")
+
+    value_frames: List[pd.DataFrame] = []
+    line_name_series: List[pd.Series] = []
+
+    for index, company_code in enumerate(valid_codes, 1):
+        print(format_progress(index, len(valid_codes), "Statements"))
+
+        result = _collect_company_statements(company_code, years, statement_type)
+
+        if result is None:
+            continue
+
+        names, values = result
+
+        value_frames.append(values)
+        line_name_series.append(names.rename(company_code))
+
+    if not value_frames:
+        print("No statement data collected")
+        return pd.DataFrame()
+
+    combined_values = pd.concat(value_frames, axis=1, sort=True)
+
+    if line_name_series:
+        names_frame = pd.concat(line_name_series, axis=1, sort=True)
+        line_name_column = names_frame.bfill(axis=1).iloc[:, 0]
+    else:
+        line_name_column = pd.Series(index=combined_values.index, dtype=object)
+
+    combined_values.insert(0, 'line_name', line_name_column)
+    combined_values.index.name = 'line_code'
+
+    return combined_values


### PR DESCRIPTION
## Summary
- add SOAP endpoint helper to download detailed financial statements by year
- parse statement metadata into a structure keyed by line codes and merge statement columns per company
- expose a multi-company statement orchestrator that returns NaN-aligned joins across requested companies

## Testing
- python -m compileall rik_screener

------
https://chatgpt.com/codex/tasks/task_e_68d3f9f90b7c8324a55165a005cbccc9