### PR TITLE
Improve API financial statements encoding and cleanup

### DIFF
--- a/rik_screener/api_workspace/__init__.py
+++ b/rik_screener/api_workspace/__init__.py
@@ -1,9 +1,10 @@
-from .main_orchestrator import get_latest_reports_info
+from .main_orchestrator import get_latest_reports_info, get_financial_statements
 from .config_auth import set_api_config, get_api_config
 from .endpoints import get_annual_reports_list, get_company_basic_info
 
 __all__ = [
     'get_latest_reports_info',
+    'get_financial_statements',
     'set_api_config',
     'get_api_config',
     'get_annual_reports_list',

--- a/rik_screener/api_workspace/data_processors.py
+++ b/rik_screener/api_workspace/data_processors.py
@@ -1,6 +1,35 @@
 import pandas as pd
 import xml.etree.ElementTree as ET
-from typing import List, Optional, Dict, Any
+from typing import List, Optional, Dict, Any, Iterable
+
+
+def _normalize_text(value: str) -> str:
+    """Normalize text values to ensure proper UTF-8 decoding."""
+
+    try:
+        return value.encode("latin1").decode("utf-8")
+    except (UnicodeEncodeError, UnicodeDecodeError):
+        return value
+
+STATEMENT_METADATA: Dict[str, Dict[str, List[str]]] = {
+    "BS": {
+        "primary": ["Bilanss"],
+        "alternatives": []
+    },
+    "IS": {
+        "primary": ["Kasumiaruanne skeem 1"],
+        "alternatives": ["Kasumiaruanne skeem 2"]
+    }
+}
+
+def _safe_text(element: Optional[ET.Element]) -> Optional[str]:
+    if element is None or element.text is None:
+        return None
+    text = element.text.strip()
+    if not text:
+        return None
+
+    return _normalize_text(text)
 
 def parse_annual_reports_response(xml_response: ET.Element, company_code: str) -> Optional[Dict[str, Any]]:
     try:
@@ -51,10 +80,118 @@ def parse_company_info_response(xml_response: ET.Element, company_code: str) -> 
 
 def create_latest_reports_dataframe(reports_data: List[Dict[str, Any]], names_data: Optional[Dict[str, str]] = None) -> pd.DataFrame:
     df = pd.DataFrame(reports_data)
-    
+
     if names_data:
         df['company_name'] = df['company_code'].map(names_data)
         cols = ['company_code', 'company_name', 'latest_year', 'period_start', 'period_end']
         df = df[cols]
-    
+
     return df
+
+def extract_statement_code(
+    xml_response: ET.Element,
+    years: Iterable[int],
+    statement_type: str
+) -> str:
+    ns = {
+        'ns1': 'http://arireg.x-road.eu/producer/',
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/'
+    }
+
+    metadata = STATEMENT_METADATA.get(statement_type.upper())
+    if metadata is None:
+        raise ValueError(f"Unsupported statement type '{statement_type}'")
+
+    entries = xml_response.findall('.//ns1:majandusaasta_aruanded', ns)
+    if not entries:
+        raise ValueError("No annual reports available for the requested company")
+
+    codes: List[str] = []
+
+    for year in years:
+        primary_code: Optional[str] = None
+        alternative_code: Optional[str] = None
+
+        for entry in entries:
+            entry_year = _safe_text(entry.find('ns1:aruande_aasta', ns))
+            entry_name = _safe_text(entry.find('ns1:aruande_nimetus', ns))
+            entry_code = _safe_text(entry.find('ns1:aruande_kood', ns))
+
+            if entry_year is None or entry_name is None or entry_code is None:
+                continue
+
+            try:
+                entry_year_int = int(entry_year)
+            except ValueError:
+                continue
+
+            if entry_year_int != year:
+                continue
+
+            if entry_name in metadata['primary']:
+                primary_code = entry_code
+                break
+
+            if entry_name in metadata['alternatives']:
+                alternative_code = entry_code
+
+        if primary_code is not None:
+            codes.append(primary_code)
+        elif alternative_code is not None:
+            codes.append(alternative_code)
+        else:
+            raise ValueError(f"No {statement_type.upper()} code found for year {year}")
+
+    unique_codes = set(codes)
+    if len(unique_codes) > 1:
+        raise ValueError("Change in reporting structure detected across requested years")
+
+    return codes[0]
+
+def parse_financial_statement_response(xml_response: ET.Element) -> pd.DataFrame:
+    ns = {
+        'ns1': 'http://arireg.x-road.eu/producer/',
+        'soapenv': 'http://schemas.xmlsoap.org/soap/envelope/'
+    }
+
+    rows = []
+
+    for entry in xml_response.findall('.//ns1:majandusaasta_aruanded_read', ns):
+        line_code = _safe_text(entry.find('ns1:rea_nr', ns))
+        line_name = _safe_text(entry.find('ns1:rea_nimetus', ns))
+
+        for column in entry.findall('ns1:majandusaasta_aruanded_veerud', ns):
+            column_code = _safe_text(column.find('ns1:veeru_kood', ns))
+            column_name = _safe_text(column.find('ns1:veeru_nimetus', ns))
+            value_text = _safe_text(column.find('ns1:vaartus', ns))
+
+            if line_code is None or column_code is None:
+                continue
+
+            value = pd.to_numeric(value_text, errors='coerce') if value_text is not None else None
+
+            rows.append({
+                'line_code': line_code,
+                'line_name': line_name,
+                'column_code': column_code,
+                'column_name': column_name,
+                'value': value
+            })
+
+    if not rows:
+        return pd.DataFrame(columns=['line_code', 'line_name'])
+
+    df = pd.DataFrame(rows)
+
+    pivot = df.pivot_table(
+        index=['line_code', 'line_name'],
+        columns='column_code',
+        values='value',
+        aggfunc='first'
+    )
+
+    pivot = pivot.sort_index(axis=1)
+    pivot.columns = pivot.columns.astype(str)
+    pivot.reset_index(inplace=True)
+
+    return pivot

--- a/rik_screener/api_workspace/endpoints.py
+++ b/rik_screener/api_workspace/endpoints.py
@@ -11,3 +11,18 @@ def get_company_basic_info(company_code: str) -> Optional[ET.Element]:
     client = SOAPClient()
     params = {"ariregistri_kood": company_code}
     return client.call_endpoint("lihtandmed_v2", params)
+
+def get_financial_statement_details(
+    company_code: str,
+    statement_code: str,
+    year: int
+) -> Optional[ET.Element]:
+    """Retrieve a specific financial statement for a company and year."""
+
+    client = SOAPClient()
+    params = {
+        "ariregistri_kood": company_code,
+        "aruande_liik": statement_code,
+        "aruandeaasta": str(year)
+    }
+    return client.call_endpoint("majandusaastaAruanneteKirjed_v1", params)

--- a/rik_screener/api_workspace/main_orchestrator.py
+++ b/rik_screener/api_workspace/main_orchestrator.py
@@ -1,9 +1,22 @@
+from datetime import datetime
+from typing import Iterable, List, Optional, Tuple
+
 import pandas as pd
-from typing import List, Optional
+
 from .config_auth import set_api_config
-from .endpoints import get_annual_reports_list, get_company_basic_info
-from .data_processors import parse_annual_reports_response, parse_company_info_response, create_latest_reports_dataframe
-from .utils import validate_company_codes, format_progress
+from .endpoints import (
+    get_annual_reports_list,
+    get_company_basic_info,
+    get_financial_statement_details,
+)
+from .data_processors import (
+    create_latest_reports_dataframe,
+    extract_statement_code,
+    parse_annual_reports_response,
+    parse_company_info_response,
+    parse_financial_statement_response,
+)
+from .utils import format_progress, validate_company_codes
 
 def get_latest_reports_info(
     company_codes: List[str],
@@ -55,7 +68,172 @@ def get_latest_reports_info(
                     names_data[company_code] = company_name
     
     df = create_latest_reports_dataframe(reports_data, names_data)
-    
+
     print(f"\nCompleted: {len(df)} companies processed successfully")
-    
+
     return df
+
+def _generate_years(starting_year: int, num_requests: int, step: int) -> List[int]:
+    return [starting_year - (step * i) for i in range(num_requests)]
+
+def _merge_year_frames(existing: pd.DataFrame, new_frame: pd.DataFrame) -> pd.DataFrame:
+    if existing is None:
+        return new_frame
+
+    union_index = existing.index.union(new_frame.index)
+
+    existing_values = existing.drop(columns=['line_name'], errors='ignore').reindex(union_index)
+    new_values = new_frame.drop(columns=['line_name'], errors='ignore').reindex(union_index)
+
+    merged_values = pd.concat([existing_values, new_values], axis=1)
+
+    existing_names = existing['line_name'] if 'line_name' in existing else pd.Series(dtype=object)
+    new_names = new_frame['line_name'] if 'line_name' in new_frame else pd.Series(dtype=object)
+
+    if existing_names.empty and not new_names.empty:
+        merged_names = new_names.reindex(union_index)
+    elif new_names.empty and not existing_names.empty:
+        merged_names = existing_names.reindex(union_index)
+    else:
+        merged_names = existing_names.reindex(union_index).combine_first(new_names.reindex(union_index))
+
+    if not merged_names.empty:
+        merged_values.insert(0, 'line_name', merged_names)
+
+    merged_values.index.name = 'line_code'
+
+    return merged_values
+
+def _collect_company_statements(
+    company_code: str,
+    years: Iterable[int],
+    statement_type: str
+) -> Optional[Tuple[pd.Series, pd.DataFrame]]:
+
+    xml_list = get_annual_reports_list(company_code)
+    if xml_list is None:
+        print(f"Failed to retrieve annual reports list for {company_code}")
+        return None
+
+    try:
+        statement_code = extract_statement_code(xml_list, years, statement_type)
+    except ValueError as exc:
+        print(f"{company_code}: {exc}")
+        return None
+
+    combined_frame: Optional[pd.DataFrame] = None
+
+    for year in years:
+        statement_xml = get_financial_statement_details(company_code, statement_code, year)
+
+        if statement_xml is None:
+            print(f"{company_code}: failed to retrieve {statement_type} for {year}")
+            continue
+
+        year_frame = parse_financial_statement_response(statement_xml)
+
+        if year_frame.empty:
+            continue
+
+        year_frame = year_frame.set_index('line_code')
+
+        value_columns = [col for col in year_frame.columns if col != 'line_name']
+        rename_map = {col: f"{year}_{col}" for col in value_columns}
+        year_frame = year_frame.rename(columns=rename_map)
+
+        combined_frame = _merge_year_frames(combined_frame, year_frame)
+
+    if combined_frame is None or combined_frame.empty:
+        print(f"{company_code}: no statement data retrieved")
+        return None
+
+    value_frame = combined_frame.drop(columns=['line_name'], errors='ignore')
+
+    if value_frame.empty:
+        print(f"{company_code}: statement contains no numeric values")
+        return None
+
+    line_names = combined_frame['line_name'] if 'line_name' in combined_frame else pd.Series(dtype=object)
+    line_names = line_names.reindex(value_frame.index)
+    line_names.name = 'line_name'
+
+    multi_columns = pd.MultiIndex.from_tuples(
+        [(company_code, column) for column in value_frame.columns],
+        names=['company_code', 'period']
+    )
+
+    value_frame.columns = multi_columns
+    value_frame.index.name = 'line_code'
+
+    return line_names, value_frame
+
+def get_financial_statements(
+    company_codes: List[str],
+    username: str,
+    password: str,
+    statement_type: str = "BS",
+    starting_year: Optional[int] = None,
+    num_requests: int = 1,
+    year_step: int = 2,
+    rate_limit: int = 20
+) -> pd.DataFrame:
+
+    if num_requests < 1:
+        raise ValueError("num_requests must be at least 1")
+
+    if year_step < 1:
+        raise ValueError("year_step must be at least 1")
+
+    if starting_year is None:
+        starting_year = datetime.utcnow().year
+
+    years = _generate_years(starting_year, num_requests, year_step)
+
+    set_api_config(username, password, rate_limit)
+
+    valid_codes = validate_company_codes(company_codes)
+
+    if not valid_codes:
+        print("No valid company codes provided")
+        return pd.DataFrame()
+
+    print(f"Processing {len(valid_codes)} companies for {statement_type.upper()} statements")
+
+    value_frames: List[pd.DataFrame] = []
+    line_name_series: List[pd.Series] = []
+
+    for index, company_code in enumerate(valid_codes, 1):
+        print(format_progress(index, len(valid_codes), "Statements"))
+
+        result = _collect_company_statements(company_code, years, statement_type)
+
+        if result is None:
+            continue
+
+        names, values = result
+
+        value_frames.append(values)
+        line_name_series.append(names.rename(company_code))
+
+    if not value_frames:
+        print("No statement data collected")
+        return pd.DataFrame()
+
+    combined_values = pd.concat(value_frames, axis=1, sort=True)
+
+    zero_rows = combined_values.fillna(0).eq(0).all(axis=1)
+    if zero_rows.any():
+        combined_values = combined_values.loc[~zero_rows]
+
+    if line_name_series:
+        names_frame = pd.concat(line_name_series, axis=1, sort=True)
+        names_frame = names_frame.reindex(combined_values.index)
+        line_name_column = names_frame.bfill(axis=1).iloc[:, 0]
+    else:
+        line_name_column = pd.Series(index=combined_values.index, dtype=object)
+
+    line_name_column = line_name_column.reindex(combined_values.index)
+    combined_values.insert(0, 'line_name', line_name_column)
+    combined_values.index.name = 'line_code'
+
+    return combined_values

--- a/rik_screener/utils/config.py
+++ b/rik_screener/utils/config.py
@@ -20,7 +20,7 @@ class ConfigManager:
         return {
             'years': [2023, 2022, 2021],
             'legal_forms': ["AS", "OÜ"],
-            'encoding': 'utf-8',
+            'encoding': 'utf-8-sig',
             'csv_separator': ';',
             'chunk_size': 500000,
             'decimal_separator': '.',

--- a/tests/test_api_financial_statements.py
+++ b/tests/test_api_financial_statements.py
@@ -1,0 +1,136 @@
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from rik_screener.api_workspace import data_processors, main_orchestrator
+
+
+def _wrap_with_envelope(inner_xml: str) -> str:
+    return (
+        "<?xml version='1.0' encoding='UTF-8'?>"
+        "<soapenv:Envelope xmlns:soapenv='http://schemas.xmlsoap.org/soap/envelope/'"
+        " xmlns:ns1='http://arireg.x-road.eu/producer/'>"
+        "<soapenv:Body>"
+        f"{inner_xml}"  # inner xml already contains ns1 tags
+        "</soapenv:Body>"
+        "</soapenv:Envelope>"
+    )
+
+
+def _build_reports_list_xml(year_to_name_code):
+    items = []
+    for year, (name, code) in year_to_name_code.items():
+        items.append(
+            "<ns1:majandusaasta_aruanded>"
+            f"<ns1:aruande_aasta>{year}</ns1:aruande_aasta>"
+            f"<ns1:aruande_nimetus>{name}</ns1:aruande_nimetus>"
+            f"<ns1:aruande_kood>{code}</ns1:aruande_kood>"
+            "</ns1:majandusaasta_aruanded>"
+        )
+    inner_xml = "<ns1:majandusaastaAruanneteLoetelu_v1Response>" "<ns1:keha>" + "".join(items) + "</ns1:keha>" "</ns1:majandusaastaAruanneteLoetelu_v1Response>"
+    return ET.fromstring(_wrap_with_envelope(inner_xml))
+
+
+def _build_statement_xml(lines):
+    rows_xml = []
+    for line_code, line_name, columns in lines:
+        cols_xml = []
+        for column_code, column_name, value in columns:
+            cols_xml.append(
+                "<ns1:majandusaasta_aruanded_veerud>"
+                f"<ns1:veeru_kood>{column_code}</ns1:veeru_kood>"
+                f"<ns1:veeru_nimetus>{column_name}</ns1:veeru_nimetus>"
+                f"<ns1:vaartus>{value}</ns1:vaartus>"
+                "</ns1:majandusaasta_aruanded_veerud>"
+            )
+        rows_xml.append(
+            "<ns1:majandusaasta_aruanded_read>"
+            f"<ns1:rea_nr>{line_code}</ns1:rea_nr>"
+            f"<ns1:rea_nimetus>{line_name}</ns1:rea_nimetus>"
+            + "".join(cols_xml)
+            + "</ns1:majandusaasta_aruanded_read>"
+        )
+    inner_xml = "<ns1:majandusaastaAruanneteKirjed_v1Response>" "<ns1:keha>" + "".join(rows_xml) + "</ns1:keha>" "</ns1:majandusaastaAruanneteKirjed_v1Response>"
+    return ET.fromstring(_wrap_with_envelope(inner_xml))
+
+
+def test_extract_statement_code_prefers_primary():
+    xml_response = _build_reports_list_xml({
+        2023: ("Bilanss", "101"),
+        2021: ("Kasumiaruanne skeem 1", "555"),
+    })
+
+    code = data_processors.extract_statement_code(xml_response, [2023], "BS")
+
+    assert code == "101"
+
+
+def test_extract_statement_code_accepts_alternative():
+    xml_response = _build_reports_list_xml({
+        2023: ("Kasumiaruanne skeem 2", "202"),
+    })
+
+    code = data_processors.extract_statement_code(xml_response, [2023], "IS")
+
+    assert code == "202"
+
+
+def test_get_financial_statements_merges_companies(monkeypatch):
+    company_reports = {
+        "1111111": _build_reports_list_xml({2023: ("Bilanss", "900")}),
+        "2222222": _build_reports_list_xml({2023: ("Bilanss", "900")}),
+    }
+
+    statement_payloads = {
+        ("1111111", 2023): _build_statement_xml([
+            ("10", "Assets", [("KR", "Kokku", "1000")]),
+            ("20", "Equity", [("KR", "Kokku", "200")]),
+        ]),
+        ("2222222", 2023): _build_statement_xml([
+            ("10", "Assets", [("KR", "Kokku", "1500")]),
+            ("30", "Liabilities", [("KR", "Kokku", "300")]),
+        ]),
+    }
+
+    def fake_get_list(company_code):
+        return ET.fromstring(ET.tostring(company_reports[company_code]))
+
+    def fake_get_statement(company_code, statement_code, year):
+        assert statement_code == "900"
+        return ET.fromstring(ET.tostring(statement_payloads[(company_code, year)]))
+
+    monkeypatch.setattr(main_orchestrator, "get_annual_reports_list", fake_get_list)
+    monkeypatch.setattr(main_orchestrator, "get_financial_statement_details", fake_get_statement)
+
+    df = main_orchestrator.get_financial_statements(
+        company_codes=["1111111", "2222222"],
+        username="user",
+        password="pass",
+        statement_type="BS",
+        starting_year=2023,
+        num_requests=1,
+        year_step=1,
+    )
+
+    assert not df.empty
+    assert list(df.columns.get_level_values(0)[1:]) == ["1111111", "2222222"]
+    assert ("line_name" in df.columns) or (df.columns[0] == "line_name")
+
+    line_name_col = df["line_name"] if "line_name" in df.columns else df.iloc[:, 0]
+    assert line_name_col.loc["10"] == "Assets"
+
+    first_company_col = ("1111111", "2023_KR")
+    second_company_col = ("2222222", "2023_KR")
+
+    assert pytest.approx(df.loc["10", first_company_col]) == 1000
+    assert pytest.approx(df.loc["10", second_company_col]) == 1500
+    assert pd.isna(df.loc["20", second_company_col])
+    assert pytest.approx(df.loc["30", second_company_col]) == 300
+    assert pd.isna(df.loc["30", first_company_col])


### PR DESCRIPTION
## Summary
- normalize statement text fields during SOAP parsing to preserve Estonian characters
- drop rows that are zero across all companies/periods when merging statement data
- default CSV encoding to UTF-8 with BOM to ensure Excel displays umlauts correctly

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68d3f9f90b7c8324a55165a005cbccc9